### PR TITLE
Configure more xDebug settings and adapt for "Docker for Mac"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # IntelliJ
 .idea/
 *.iml
+wordpress_sources/*

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ You can use the following environment variables to configure MySQL and WordPress
 
 * **XDEBUG_PORT** (default is '9000')
   * Port used by Xdebug to connect to IDE 
+* **XDEBUG_HOST** (default is auto-detected)
+  * Host used by Xdebug to connect to IDE.
+    Leave empty by default or set to "docker.for.mac.localhost" if use Docker for Mac.
+* **XDEBUG_REMOTE_AUTOSTART** (default is "on")
+  * Start a debug session automatically.
+* **XDEBUG_REMOTE_CONNECT_BACK** (default is "off")
+  * Try to connect to the client that made the HTTP request
+   (could be problematic to use with Docker for Mac, use appropriate `XDEBUG_HOST` setting instead)
+* **XDEBUG_REMOTE_KEY** (default is empty)
+  * IDE Key, for example 'PHPSTORM'
 * **MYSQL_WP_USER** (default is 'WordPress')
   * MySQL user, used by WordPress
 * **MYSQL_WP_PASSWORD** (default is 'secret')

--- a/config_xdebug.sh
+++ b/config_xdebug.sh
@@ -2,10 +2,32 @@
 
 if [ ! -f /xdebug_configured ]; then
     echo "=> Xdebug is not configured yet, configuring Xdebug ..."
-    DOCKER_HOST_IP=$(netstat -nr | grep '^0\.0\.0\.0' | awk '{print $2}')
-    echo "xdebug.remote_enable=on" >> /etc/php5/mods-available/xdebug.ini
-    echo "xdebug.remote_host=$DOCKER_HOST_IP" >> /etc/php5/mods-available/xdebug.ini
-    echo "xdebug.remote_port=$XDEBUG_PORT" >> /etc/php5/mods-available/xdebug.ini
+    echo "xdebug.remote_enable=on" >> /etc/php/5.6/mods-available/xdebug.ini
+
+    if [ -z $XDEBUG_REMOTE_AUTOSTART ]; then
+        XDEBUG_REMOTE_AUTOSTART="on"
+    fi
+    echo "xdebug.remote_autostart=$XDEBUG_REMOTE_AUTOSTART" >> /etc/php/5.6/mods-available/xdebug.ini
+
+    # https://xdebug.org/docs/all_settings#remote_connect_back
+    # 1. If enabled, the xdebug.remote_host setting is ignored
+    # 2. Doesn't work correctly if Docker for Mac is used
+    if [ -z $XDEBUG_REMOTE_CONNECT_BACK ] ; then
+        XDEBUG_REMOTE_CONNECT_BACK="off"
+    fi
+    echo "xdebug.remote_connect_back=$XDEBUG_REMOTE_CONNECT_BACK" >> /etc/php/5.6/mods-available/xdebug.ini
+
+    if [ "$XDEBUG_REMOTE_CONNECT_BACK" != "on" ] && [ "$XDEBUG_REMOTE_CONNECT_BACK" != "On" ]; then
+        if [ -z $XDEBUG_HOST ] ; then
+            XDEBUG_HOST=$(netstat -nr | grep '^0\.0\.0\.0' | awk '{print $2}')
+        fi
+        echo "xdebug.remote_host=$XDEBUG_HOST" >> /etc/php/5.6/mods-available/xdebug.ini
+        echo "xdebug.remote_port=$XDEBUG_PORT" >> /etc/php/5.6/mods-available/xdebug.ini
+    fi
+
+    if ! [ -z $XDEBUG_REMOTE_KEY ] ; then
+        echo "xdebug.xdebug.remote_key=$XDEBUG_REMOTE_KEY" >> /etc/php/5.6/mods-available/xdebug.ini
+    fi
 
     touch /xdebug_configured
 else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2'
+services:
+  wordpress-xdebug:
+      build: ./
+#      image: 'kaihofstetter/docker-wordpress-xdebug:latest'
+#      image: 'codeneric/wordpress-xdebug:latest'
+      image: 'docker-wordpress-xdebug' # local
+      ports:
+        - '80:80'
+        - '3306:3306'
+      volumes:
+        - './wordpress_sources:/wordpress_sources'
+      environment:
+        - XDEBUG_PORT=9000
+        - XDEBUG_HOST=docker.for.mac.localhost
+        - XDEBUG_REMOTE_KEY=PHPSTORM
+        - XDEBUG_REMOTE_AUTOSTART=on
+        - MYSQL_WP_USER=wordpress
+        - MYSQL_WP_PASSWORD=wordpress
+        - WP_URL=localhost:8082
+        - WP_TITLE=Wordpress with Xdebug
+        - WP_ADMIN_USER=admin
+        - WP_ADMIN_PASSWORD=admin
+        - WP_ADMIN_EMAIL=admin@localhost
+volumes:
+  wordpress_sources:
+    driver: local


### PR DESCRIPTION
It is a copy of changes made for a more fresh fork from @kingkrausel: https://github.com/codeneric/docker-wordpress-xdebug/pull/1

The changes never tested with this repo so [other open issues](https://github.com/KaiHofstetter/docker-wordpress-xdebug/issues/1) could affect this too.

- Do not use `xdebug.remote_autostart` together with `xdebug.remote_host`.
- Allow to set `XDEBUG_HOST` from environment.
- Add `xdebug.remote_key` option.
- Add `docker-compose.yaml` example configured for "Docker for Mac".